### PR TITLE
Add link to quick AI analysis

### DIFF
--- a/app/schemas/analysis.py
+++ b/app/schemas/analysis.py
@@ -47,8 +47,10 @@ class AnalysisResponse(BaseModel):
 
 class QuickAnalysisResponse(BaseModel):
     """Краткий анализ для быстрого просмотра"""
+    success: bool
+    filter_name: str
     total_cars: int
-    top_3_recommendations: List[str]
-    average_price_range: str
-    best_value_car: Optional[CarSummary] = None
-    analysis_summary: str
+    quick_recommendation: str
+    recommended_link: Optional[str] = None
+    analysis_type: str
+    error: Optional[str] = None

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -4,6 +4,7 @@ from app.services.openai_service import OpenAIService
 from app.repository.car_repository import CarRepository
 from app.database import async_session
 import logging
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -121,11 +122,23 @@ class AnalysisService:
                 # Используем быстрый метод OpenAI service
                 quick_rec = await self.openai_service.get_quick_recommendation(cars)
 
+                # Пытаемся извлечь номер рекомендованного автомобиля из текста
+                recommended_link = None
+                match = re.search(r"#(\d+)", quick_rec)
+                if match:
+                    try:
+                        idx = int(match.group(1)) - 1
+                        if 0 <= idx < len(cars):
+                            recommended_link = cars[idx].link
+                    except Exception:
+                        recommended_link = None
+
                 return {
                     "success": True,
                     "filter_name": filter_name,
                     "total_cars": len(cars),
                     "quick_recommendation": quick_rec,
+                    "recommended_link": recommended_link,
                     "analysis_type": "quick_insight"
                 }
 

--- a/app/services/telegram_service.py
+++ b/app/services/telegram_service.py
@@ -181,6 +181,7 @@ class TelegramService:
             filter_name = analysis_result.get("filter_name", "машин")
             total_cars = analysis_result.get("total_cars", 0)
             quick_rec = analysis_result.get("quick_recommendation", "Нет рекомендации")
+            rec_link = analysis_result.get("recommended_link")
 
             # Обрезаем рекомендацию если слишком длинная
             if len(quick_rec) > 200:
@@ -193,6 +194,12 @@ class TelegramService:
 
 🤖 <b>Рекомендация:</b>
 {quick_rec}
+"""
+
+            if rec_link:
+                message += f"\n🔗 <a href=\"{rec_link}\">Посмотреть объявление</a>"
+
+            message += """
 
 💡 <i>Для детального анализа используйте /analysis</i>
 """


### PR DESCRIPTION
## Summary
- extract recommended car link in quick analysis results
- include hyperlink in Telegram quick analysis notifications
- expose recommended link field in QuickAnalysisResponse schema

## Testing
- `make test` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe90c1a4c8323b8a40e63bc25062c