### PR TITLE
Update Docker entrypoint and main module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Install Chrome and ChromeDriver
 RUN apt-get update && apt-get install -y \
@@ -48,4 +48,4 @@ COPY . .
 # Устанавливаем права доступа для директорий
 RUN chmod -R 755 /app/reports /app/logs
 
-CMD ["python", "startup.py"]
+ENTRYPOINT ["python", "-m", "app.main"]

--- a/app/main.py
+++ b/app/main.py
@@ -97,3 +97,8 @@ async def health():
             "reports": "/reports"
         }
     }
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- update Dockerfile to use `python:3.12-slim` and run the app module
- enable running `app.main` directly

## Testing
- `pytest -q`
- `make test` *(fails: `docker-compose` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416e4858308323a1650cddf2563fb1